### PR TITLE
Fix `validate()` returned value

### DIFF
--- a/flask_session_captcha/__init__.py
+++ b/flask_session_captcha/__init__.py
@@ -84,7 +84,7 @@ class FlaskSessionCaptcha(object):
 
         # invalidate the answer to stop new tries on the same challenge.
         session['captcha_answer'] = None
-        return value and value == session_value
+        return value is not None and value == session_value
 
     def get_answer(self):
         """


### PR DESCRIPTION
If `value` is `None`, it would return `None` and not `False`.